### PR TITLE
weapon names & binds

### DIFF
--- a/action/autoexec.cfg
+++ b/action/autoexec.cfg
@@ -46,16 +46,16 @@ seta lookstrafe "0"
  *  Movement and weapon
  * =====================
  */
-//bind W "+forward"                     // move forward
-//bind S "+back"                        // move backward
-//bind A "+moveleft"                    // move left
-//bind D "+moveright"                   // move right
+//bind w "+forward"                     // move forward
+//bind s "+back"                        // move backward
+//bind a "+moveleft"                    // move left
+//bind d "+moveright"                   // move right
 //bind MOUSE2 "+moveup"                 // jump
 //bind MOUSE1 "+attack"                 // shoot
-//bind R "reload"                       // reload
+//bind r "reload"                       // reload
 //bind SHIFT "+speed"                   // hold to walk
 //bind SPACE "weapon"                   // change weapon mode
-//bind space "+movedown"                // crouch
+//bind CTRL "+movedown"                // crouch
 
 //seta cl_gun "3"                       // 0: no visable gun, 2: force right hand, 3: force left hand ("1" is used to let the hand cvar to set dominant hand)
 //seta cl_gunalpha "1"                  // 0-1, where 0: 100% transparent and 1: 0% transparent
@@ -65,24 +65,23 @@ seta lookstrafe "0"
  *  Action Quake2 commands
  * ========================
  */
-//bind G "use M26 Fragmentation Grenade"                // use grenades
-//bind Q weapnext                                       // use next weapon
+//bind q weapnext                                       // use next weapon
 //bind <btn> weapprev                                   // use previous weapon uncomment to bind
 
 //bind MWHEELUP "lens in"                               // zoom in
 //bind MWHEELDOWN "lens out"                            // zoom out
 //bind <btn> "lens"                                     // toggle between 1x, 2x, 4x and 6x zoom
 
-//bind Z "drop item"                                    // drop item
-//bind X "drop weapon;use throwing Combat Knife"        // drop weapon and use throwing knifes
-//bind <btn> "drop weapon;use mk23 pistol"              // drop weapon and use mk23 pistol
-//bind F "bandage"                                      // bandage if above 3 HP, see fuctions.cfg for more info
-//bind E "opendoor"                                     // open door
+//bind z "drop item"                                    // drop item
+//bind x "drop weapon;use throwing Combat Knife"        // drop weapon and use throwing knifes
+//bind <btn> "drop weapon;use MK23 Pistol"              // drop weapon and use mk23 pistol
+//bind f "bandage"                                      // bandage if above 3 HP, see fuctions.cfg for more info
+//bind e "opendoor"                                     // open door
 
-//bind 1 "use mk23 pistol"                              // use pistol
-//bind 2 "use a 2nd pistol"                             // use dual pistols
-//bind 3 "use throwing combat knife"                    // use knife (and change between slashing and throwing)
-//bind 4 "use m26 fragmentation grenade"                // use fraggranade                                                   wat bom? fair?
+//bind 1 "use MK23 Pistol"                              // use pistol
+//bind 2 "use Dual MK23 Pistols"                        // use dual pistols
+//bind 3 "use throwing Combat Knife"                    // use knife (and change between slashing and throwing)
+//bind 4 "use M26 Fragmentation Grenade"                // use fraggranade                                                   wat bom? fair?
 
 set m_autosens "1"                                      // set to 1 to use AQ2 tng´s automatic zoom sensitivity (makes cpi consistent in all zoom levels)
 
@@ -93,7 +92,7 @@ set m_autosens "1"                                      // set to 1 to use AQ2 t
  */
 //bind u "messagemode"                  // chat message to everyone on the server
 //bind y "messagemode2"                 // chat message to teammates
-//bind F1 "cmd help"                    // show score
+//bind F1 "score                        // show score
 //bind F2 "menu"                        // show menu for ignore/map-/kick-/config-voting/etc
 //bind F3 "stats"                       // show weapon statistics
 //bind F12 "screenshotjpg"              // take screenshot
@@ -269,11 +268,11 @@ set m_autosens "1"                                      // set to 1 to use AQ2 t
 
 // EU-based servers
 //seta adr5 "46.165.236.6:27910"
-//seta adr6 "95.216.138.180:27910"
+//seta adr6 "aq2.wex.fi:27910"
 //seta adr7 "79.161.90.61:27910"
-//seta adr8 "16.170.251.201:27910"
+//seta adr8 "north.aq2.eu:27910"
 //seta adr9 "212.116.37.42:27910"
-//seta adr10 "176.10.36.1:27910"
+//seta adr10 "quake.ra.is:27910"
 //seta adr11 "149.210.160.155:27910"
 
 // AU-based servers


### PR DESCRIPTION
Fixed Weapon names and lowercase alphabetical binds.
Removed dual bind for M26 Fragmentation Grenade
CTRL for crouching (was space)