### PR TITLE
Update triggers.cfg

### DIFF
--- a/action/default-configs/triggers.cfg
+++ b/action/default-configs/triggers.cfg
@@ -27,9 +27,9 @@ trigger "set round[on] 0;set roundkill[#] 0" "*$name$ entered the game*"
 trigger "set round[on] 1;set roundkill[#] 0" "*LIGHTS...*"
 trigger "set round[on] 2" "*round is over*"
 
-alias roundkill[made] "inc roundkill[#];if $round[on] == 1 then roundkill[msg]"
+alias roundkill[made] "inc roundkill[#];if $round[on] == 1 then ${qt}roundkill[msg]${sc}roundkill[radio]${qt}"
 alias roundkill[radio] "if $roundkill[#] <= 10 then radio ${roundkill[#]} else radio enemyd"
-alias roundkill[msg] "roundkill[radio];say_team ${qt} [ ${roundkill[#]} ] ${roundkill[say]} [  %K ] ${qt}"
+alias roundkill[msg] "say_team ${qt} [ ${roundkill[#]} ] ${roundkill[say]} [  %K ] ${qt}"
 
 /*
  * ===========================


### PR DESCRIPTION
roundkill[radio] is now called from roundkill[made] instead. Which makes the alias roundkill[msg] easier to customize.