### PR TITLE
Reduce differences in PKZ files between releases

### DIFF
--- a/.github/workflows/New-Content-Release.yaml
+++ b/.github/workflows/New-Content-Release.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           for makepkz in pak0 pak1; do
             cd ${makepkz}
-            zip -r ../${makepkz}.pkz * && cd ..
+            python $GITHUB_WORKSPACE/${{ env.DIST_DIR }}/scripts/pkz/pkz.py ../${makepkz}.pkz * && cd ..
             rm -rf ${makepkz}/
           done
 

--- a/.github/workflows/New-Content-Release.yaml
+++ b/.github/workflows/New-Content-Release.yaml
@@ -18,6 +18,15 @@ jobs:
           repository: actionquake/distrib
           path: ${{ env.DIST_DIR }}
 
+      - name: Fetch additional history
+        working-directory: ${{ env.DIST_DIR }}
+        run: |
+          # Set up partial clone support
+          git config remote.origin.promisor true
+          git config remote.origin.partialclonefilter blob:none
+          # Now fetches history (but not blobs!)
+          git fetch --unshallow
+
       - name: Zip game content to pkz
         working-directory: ${{ env.DIST_DIR }}/baseaq
         run: |

--- a/.github/workflows/New-Dist-Release.yaml
+++ b/.github/workflows/New-Dist-Release.yaml
@@ -20,6 +20,15 @@ jobs:
           repository: actionquake/distrib
           path: ${{ env.DIST_DIR }}
 
+      - name: Fetch additional history
+        working-directory: ${{ env.DIST_DIR }}
+        run: |
+          # Set up partial clone support
+          git config remote.origin.promisor true
+          git config remote.origin.partialclonefilter blob:none
+          # Now fetches history (but not blobs!)
+          git fetch --unshallow
+
       - name: Generate directory structure
         run: |
           mkdir -p ${{ env.AQTION_DIR }}/baseaq

--- a/.github/workflows/New-Dist-Release.yaml
+++ b/.github/workflows/New-Dist-Release.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           for makepkz in pak0 pak1; do
             cd ${makepkz}
-            zip -r ../${makepkz}.pkz * && cd ..
+            python $GITHUB_WORKSPACE/${{ env.DIST_DIR }}/scripts/pkz/pkz.py ../${makepkz}.pkz * && cd ..
             rm -rf ${makepkz}/
           done
 

--- a/scripts/pkz/pkz.py
+++ b/scripts/pkz/pkz.py
@@ -1,0 +1,75 @@
+#!python3
+
+# Copyright (C) 2023 Frank Richter
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+
+# .PKZ file creation utility
+
+import argparse
+import collections
+import concurrent.futures
+import datetime
+import os
+import subprocess
+import sys
+import zipfile
+
+
+# Command line arguments
+arguments = argparse.ArgumentParser()
+arguments.add_argument('pkzfile', metavar='PKZFILE', help="name of .pkz file to create")
+arguments.add_argument('files', metavar='FILE', nargs='+', help="file to add to .pak file")
+args = arguments.parse_args()
+
+def resolve_file_args(files):
+    """Returns an iterator that provides all files, including those in subdirectories, from the given paths"""
+    queue = collections.deque(files)
+    while len(queue) > 0:
+        path = queue.popleft()
+        if os.path.isdir(path):
+            queue.extend(map(lambda dir_entry: os.path.join(path, dir_entry), os.listdir(path)))
+        else:
+            yield path
+
+def get_git_commit_timestamp(fn):
+    """Return git commit timestamp for the given file"""
+    try:
+        log_result = subprocess.run(["git", "log", "-1", "--format=format:%cI", fn], stdout=subprocess.PIPE, encoding="utf-8", check=True)
+        timestamp_str = log_result.stdout.strip()
+        # Get timestamp in UTC
+        timestamp = datetime.datetime.fromisoformat(timestamp_str)
+        timestamp = timestamp.astimezone(datetime.timezone.utc)
+        return timestamp
+    except:
+        return None
+
+# Assemble list of files, asynchronously obtain timestamps
+executor = concurrent.futures.ThreadPoolExecutor()
+all_files = []
+for fn in sorted(resolve_file_args(args.files)):
+    all_files.append((fn, executor.submit(get_git_commit_timestamp, fn)))
+
+# Compress all files into ZIPm with timestamps obtained from the git history
+with zipfile.ZipFile(args.pkzfile, "w") as pkz:
+    for fn, timestamp in all_files:
+        print(f"{fn} ...")
+        sys.stdout.flush()
+        entry = zipfile.ZipInfo.from_file(fn)
+        timestamp = timestamp.result()
+        entry.date_time = (timestamp.year, timestamp.month,timestamp.day, timestamp.hour, timestamp.minute, timestamp.second)
+        with open(fn, "rb") as input_file:
+            pkz.writestr(entry, input_file.read(), compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)


### PR DESCRIPTION
Currently, when a new update is made available on Steam, it typically contains pretty much the complete .pkz files every time, even though only a fraction of the content itself changed.

The culprits are probably the file times recorded in the archives: since git sets the file times to the _checkout time_, ie in practice the current time when the GH Action(s) run, this is what ends up in the archives. And since ZIP entry information is _also_ recorded interspersed throughout the archive, this results in lots of little changes throughout the file, preventing Steam from effectively detecting "unchanged chunks". (Info on chunking taken from here: https://partner.steamgames.com/doc/sdk/uploading)

To make the file times recorded in the archive consistent between archive creation runs I created a Python script that does the archival, but specifically pulls the used timestamps from the git history.

Additionally, the files are now added sorted by name; the idea is that this avoids files moving around in the archive, as strictly speaking the current order is the one reported by the OS and may change for arbitrary, unknown reasons.
